### PR TITLE
List tests

### DIFF
--- a/lib/memory-provider.js
+++ b/lib/memory-provider.js
@@ -42,8 +42,21 @@ module.exports = function memoryProvider (options) {
       delete store[key]
       cb(null)
     },
-    list: function (cb) {
-      cb(null, Object.keys(store))
+    list: function (before, cb) {
+      if (typeof before === 'function') {
+        cb = before
+        before = null
+      }
+      var keys = Object.keys(store)
+
+      if (typeof before === 'string') {
+        keys = keys.filter(function (key) {
+          var regex = new RegExp('^' + before)
+          return regex.test(key)
+        })
+      }
+
+      cb(null, keys)
     }
   }
 }

--- a/lib/service-provider.js
+++ b/lib/service-provider.js
@@ -1,4 +1,5 @@
 var Wreck = require('wreck')
+var url = require('url')
 
 module.exports = function serviceProvider (config) {
   if (!config) throw new Error('Must set config for service provider')
@@ -6,6 +7,7 @@ module.exports = function serviceProvider (config) {
   if (!config.url) throw new Error('Must set url for service provider')
 
   var wreck = Wreck.defaults({
+    baseUrl: config.url,
     headers: { 'Authorization': 'Bearer ' + config.token },
     timeout: 10000
   })
@@ -22,7 +24,7 @@ module.exports = function serviceProvider (config) {
     type: 'service',
 
     get: function (key, cb) {
-      wreck.request('GET', config.url + '/persist/kv/' + key, {}, function (err, res) {
+      wreck.request('GET', '/persist/kv/' + key, null, function (err, res) {
         if (err) return cb(err)
         if (res.statusCode === 404) return cb(null, undefined)
 
@@ -38,7 +40,7 @@ module.exports = function serviceProvider (config) {
     mget: function (keys, cb) {
       var payload = JSON.stringify({ keys: keys })
 
-      wreck.request('POST', config.url + '/persist/mget', {payload: payload}, function (err, res) {
+      wreck.request('POST', '/persist/mget', {payload: payload}, function (err, res) {
         if (err) return cb(err)
 
         wreck.read(res, {json: true}, function (err, body) {
@@ -67,7 +69,7 @@ module.exports = function serviceProvider (config) {
 
       var payload = JSON.stringify({ value: wrap(value) })
 
-      wreck.request('PUT', config.url + '/persist/kv/' + key, {payload: payload}, function (err, res) {
+      wreck.request('PUT', '/persist/kv/' + key, {payload: payload}, function (err, res) {
         if (err) return cb(err)
         if (res.statusCode === 404) return cb(null, '')
 
@@ -81,7 +83,7 @@ module.exports = function serviceProvider (config) {
       })
     },
     del: function (key, cb) {
-      wreck.request('DELETE', config.url + '/persist/kv/' + key, {}, function (err, res) {
+      wreck.request('DELETE', '/persist/kv/' + key, null, function (err, res) {
         if (err) return cb(err)
         if (res.statusCode === 404) return cb(null)
         if (res.statusCode === 200) return cb(null)
@@ -94,8 +96,19 @@ module.exports = function serviceProvider (config) {
         })
       })
     },
-    list: function (cb) {
-      wreck.request('GET', config.url + '/persist/kv', {}, function (err, res) {
+    list: function (before, cb) {
+      if (typeof before === 'function') {
+        cb = before
+        before = null
+      }
+      var reqUrl = {
+        pathname: '/persist/kv'
+      }
+      if (typeof before === 'string') {
+        reqUrl.query = { before: before }
+      }
+
+      wreck.request('GET', url.format(reqUrl), null, function (err, res) {
         if (err) return cb(err)
         if (res.statusCode === 404) return cb(null, [])
 

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -17,6 +17,68 @@ describe('Memory provider', () => {
     })
   })
 
+  describe('list keys', function () {
+    it('should handle no keys', function (done) {
+      var provider = MemoryProvider()
+
+      provider.list(function (err, keys) {
+        assert.isNull(err)
+        assert.isArray(keys)
+        assert.lengthOf(keys, 0)
+
+        done()
+      })
+    })
+
+    it('should return keys after set', function (done) {
+      var provider = MemoryProvider()
+      var keys = [getKey(), getKey()]
+
+      provider.set(keys[0], 'beep', function (err) {
+        assert.isNull(err)
+
+        provider.set(keys[1], 'boop', function (err) {
+          assert.isNull(err)
+
+          provider.list(function (err, k) {
+            assert.isNull(err)
+            assert.isArray(k)
+            assert.lengthOf(k, keys.length)
+
+            done()
+          })
+        })
+      })
+    })
+
+    it("shouldn't return a key after del", function (done) {
+      var provider = MemoryProvider()
+      var key = getKey()
+
+      provider.set(key, 'beep', function (err) {
+        assert.isNull(err)
+
+        provider.list(function (err, keys) {
+          assert.isNull(err)
+          assert.isArray(keys)
+          assert.lengthOf(keys, 1)
+
+          provider.del(key, function (err) {
+            assert.isNull(err)
+
+            provider.list(function (err, keys) {
+              assert.isNull(err)
+              assert.isArray(keys)
+              assert.lengthOf(keys, 0)
+
+              done()
+            })
+          })
+        })
+      })
+    })
+  })
+
   describe('without serialize', function () {
     var config = {}
 

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -77,6 +77,44 @@ describe('Memory provider', () => {
         })
       })
     })
+
+    it('should filter keys', function (done) {
+      var provider = MemoryProvider()
+      var key1 = 'beep'
+      var key2 = 'boop'
+      var value = 'beepboop'
+
+      provider.set(key1, value, function (err) {
+        assert.isNull(err)
+
+        provider.set(key2, value, function (err) {
+          assert.isNull(err)
+
+          provider.list('be', function (err, keys) {
+            assert.isNull(err)
+            assert.isArray(keys)
+            assert.lengthOf(keys, 1)
+            assert.equal(keys[0], key1)
+
+            provider.list('bo', function (err, keys) {
+              assert.isNull(err)
+              assert.isArray(keys)
+              assert.lengthOf(keys, 1)
+              assert.equal(keys[0], key2)
+
+              provider.list('b', function (err, keys) {
+                assert.isNull(err)
+                assert.isArray(keys)
+                assert.lengthOf(keys, 2)
+                assert.deepEqual(keys, [key1, key2])
+
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
   })
 
   describe('without serialize', function () {

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -42,6 +42,124 @@ describe('Service provider', () => {
     })
   })
 
+  describe('list keys', function () {
+    var config = {
+      token: 'TOKEN',
+      url: 'https://persist'
+    }
+
+    it('should handle no keys', function (done) {
+      var provider = ServiceProvider(config)
+
+      var getKeys = nock(config.url)
+        .get('/persist/kv')
+        .reply(200, [])
+
+      provider.list(function (err, keys) {
+        assert.isNull(err)
+        assert.isArray(keys)
+        assert.lengthOf(keys, 0)
+        assert.isTrue(getKeys.isDone())
+
+        done()
+      })
+    })
+
+    it('should return keys after set', function (done) {
+      var provider = ServiceProvider(config)
+      var keys = [getKey(), getKey()]
+      var values = ['beep', 'boop']
+
+      var set1 = nock(config.url)
+        .put('/persist/kv/' + keys[0], JSON.stringify({ value: values[0] }))
+        .reply(200, {
+          key: keys[0],
+          value: values[0]
+        })
+
+      var set2 = nock(config.url)
+        .put('/persist/kv/' + keys[1], JSON.stringify({ value: values[1] }))
+        .reply(200, {
+          key: keys[1],
+          value: values[1]
+        })
+
+      var getKeys = nock(config.url)
+        .get('/persist/kv')
+        .reply(200, keys)
+
+      provider.set(keys[0], values[0], function (err) {
+        assert.isNull(err)
+        assert.isTrue(set1.isDone())
+
+        provider.set(keys[1], values[1], function (err) {
+          assert.isNull(err)
+          assert.isTrue(set2.isDone())
+
+          provider.list(function (err, k) {
+            assert.isNull(err)
+            assert.isArray(k)
+            assert.lengthOf(k, keys.length)
+            assert.isTrue(getKeys.isDone())
+
+            done()
+          })
+        })
+      })
+    })
+
+    it("shouldn't return a key after del", function (done) {
+      var provider = ServiceProvider(config)
+      var key = getKey()
+      var value = 'beep'
+
+      var set = nock(config.url)
+        .put('/persist/kv/' + key, JSON.stringify({ value: value }))
+        .reply(200, {
+          key: key,
+          value: value
+        })
+
+      var getKeys1 = nock(config.url)
+        .get('/persist/kv')
+        .reply(200, [key])
+
+      var del = nock(config.url)
+        .delete('/persist/kv/' + key)
+        .reply(200)
+
+      var getKeys2 = nock(config.url)
+        .get('/persist/kv')
+        .reply(200, [])
+
+      provider.set(key, 'beep', function (err) {
+        assert.isNull(err)
+        assert.isTrue(set.isDone())
+
+        provider.list(function (err, keys) {
+          assert.isNull(err)
+          assert.isArray(keys)
+          assert.lengthOf(keys, 1)
+          assert.isTrue(getKeys1.isDone())
+
+          provider.del(key, function (err) {
+            assert.isNull(err)
+            assert.isTrue(del.isDone())
+
+            provider.list(function (err, keys) {
+              assert.isNull(err)
+              assert.isArray(keys)
+              assert.lengthOf(keys, 0)
+              assert.isTrue(getKeys2.isDone())
+
+              done()
+            })
+          })
+        })
+      })
+    })
+  })
+
   describe('without serialize', function () {
     var config = {
       url: 'https://persist',


### PR DESCRIPTION
- Adds tests for `list()`
- Adds support for the before filter on `list()` via an optional first string param:

``` javascript
// w/o filter
persist.list(cb)

// w/ filter
persist.list('filter', cb)
```
