### PR TITLE
add debug logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,86 @@
 var deap = require('deap')
 var serviceProvider = require('./lib/service-provider')
 var memoryProvider = require('./lib/memory-provider')
+var Logger = require('./lib/logger')
 
 module.exports = function NewKV (options) {
   var config = deap.update({
+    debug: false,
     serialize: true,
     token: process.env.BEEPBOOP_TOKEN,
     url: 'http://persist'
   }, options || {})
 
-  if (!config.token) {
-    console.log('USING PERSIST IN MEMORY PROVIDER')
-    return memoryProvider(config)
-  }
+  var logger = config.logger || Logger(config.debug)
+  var provider = !config.token ? memoryProvider(config) : serviceProvider(config)
 
-  return serviceProvider(config)
+  // return a wrapper around provider to normalize args and logging
+  return {
+    type: provider.type,
+
+    get: function (key, cb) {
+      provider.get(key, function (err, value) {
+        if (err) {
+          logger.error('Error calling get(%s): %s', key, err.message)
+        } else {
+          logger.debug('get(%s)', key)
+        }
+
+        cb(err, value)
+      })
+    },
+    mget: function (keys, cb) {
+      provider.mget(keys, function (err, value) {
+        if (err) {
+          logger.error('Error calling mget([%s]): %s', keys.join(','), err.message)
+        } else {
+          logger.debug('mget([%s])', keys.join(','))
+        }
+
+        cb(err, value)
+      })
+    },
+    set: function (key, value, cb) {
+      cb = cb || noop
+
+      provider.set(key, value, function (err, value) {
+        if (err) {
+          logger.error('Error calling set(%s): %s', key, err.message)
+        } else {
+          logger.debug('set(%s)', key)
+        }
+
+        cb(err, value)
+      })
+    },
+    del: function (key, cb) {
+      provider.del(key, function (err, value) {
+        if (err) {
+          logger.error('Error calling del(%s): %s', key, err.message)
+        } else {
+          logger.debug('del(%s)', key)
+        }
+
+        cb(err, value)
+      })
+    },
+    list: function (before, cb) {
+      if (typeof before === 'function') {
+        cb = before
+        before = null
+      }
+
+      provider.list(before, function (err, value) {
+        if (err) {
+          logger.error('Error calling list(): %s', err.message)
+        } else {
+          logger.debug('list()')
+        }
+
+        cb(err, value)
+      })
+    }
+  }
 }
+
+function noop () {}

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,20 @@
+
+module.exports = function Logger (debug) {
+  return {
+    debug: function () {
+      if (debug) {
+        var args = Array.prototype.slice.call(arguments)
+        args[0] = 'debug: ' + args[0]
+        console.log.apply(console, args)
+      }
+    },
+
+    error: function () {
+      if (debug) {
+        var args = Array.prototype.slice.call(arguments)
+        args[0] = 'error: ' + args[0]
+        console.log.apply(console, args)
+      }
+    }
+  }
+}

--- a/lib/memory-provider.js
+++ b/lib/memory-provider.js
@@ -31,12 +31,12 @@ module.exports = function memoryProvider (config) {
     set: function (key, value, cb) {
       // can't serialize this - treat as an error
       if (value === undefined) {
-        if (cb) return cb(new Error('cannot set a value of undefined'))
+        return cb(new Error('cannot set a value of undefined'))
       }
 
       store[key] = serialize ? JSON.stringify(value) : value
 
-      if (cb) cb(null, value)
+      cb(null, value)
     },
     del: function (key, cb) {
       delete store[key]

--- a/lib/memory-provider.js
+++ b/lib/memory-provider.js
@@ -1,6 +1,6 @@
 
-module.exports = function memoryProvider (options) {
-  var serialize = options && options.serialize
+module.exports = function memoryProvider (config) {
+  var serialize = config && !!config.serialize
 
   var store = {}
 
@@ -43,10 +43,6 @@ module.exports = function memoryProvider (options) {
       cb(null)
     },
     list: function (before, cb) {
-      if (typeof before === 'function') {
-        cb = before
-        before = null
-      }
       var keys = Object.keys(store)
 
       if (typeof before === 'string') {

--- a/lib/service-provider.js
+++ b/lib/service-provider.js
@@ -97,10 +97,6 @@ module.exports = function serviceProvider (config) {
       })
     },
     list: function (before, cb) {
-      if (typeof before === 'function') {
-        cb = before
-        before = null
-      }
       var reqUrl = {
         pathname: '/persist/kv'
       }

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -1,14 +1,14 @@
 var assert = require('chai').assert
-var MemoryProvider = require('../lib/memory-provider')
+var Persist = require('../index')
 
 describe('Memory provider', () => {
   it('should initialize', () => {
-    var provider = MemoryProvider()
+    var provider = Persist({ token: null })
     assert(typeof provider === 'object')
   })
 
   it('should set without a callback', function (done) {
-    var provider = MemoryProvider()
+    var provider = Persist({ token: null })
 
     assert.doesNotThrow(function () {
       provider.set(getKey(), 'value')
@@ -19,7 +19,7 @@ describe('Memory provider', () => {
 
   describe('list keys', function () {
     it('should handle no keys', function (done) {
-      var provider = MemoryProvider()
+      var provider = Persist({ token: null })
 
       provider.list(function (err, keys) {
         assert.isNull(err)
@@ -31,7 +31,7 @@ describe('Memory provider', () => {
     })
 
     it('should return keys after set', function (done) {
-      var provider = MemoryProvider()
+      var provider = Persist({ token: null })
       var keys = [getKey(), getKey()]
 
       provider.set(keys[0], 'beep', function (err) {
@@ -52,7 +52,7 @@ describe('Memory provider', () => {
     })
 
     it("shouldn't return a key after del", function (done) {
-      var provider = MemoryProvider()
+      var provider = Persist({ token: null })
       var key = getKey()
 
       provider.set(key, 'beep', function (err) {
@@ -79,7 +79,7 @@ describe('Memory provider', () => {
     })
 
     it('should filter keys', function (done) {
-      var provider = MemoryProvider()
+      var provider = Persist({ token: null })
       var key1 = 'beep'
       var key2 = 'boop'
       var value = 'beepboop'
@@ -118,7 +118,7 @@ describe('Memory provider', () => {
   })
 
   describe('without serialize', function () {
-    var config = {}
+    var config = { token: null }
 
     testMiss(config)
     testSetUndefined(config)
@@ -134,6 +134,7 @@ describe('Memory provider', () => {
 
   describe('with serialize', function () {
     var config = {
+      token: null,
       serialize: true
     }
 
@@ -151,7 +152,7 @@ describe('Memory provider', () => {
 
   function testSetGetDelGet (config, value) {
     it('should handle "' + value + '"', function (done) {
-      var provider = MemoryProvider(config)
+      var provider = Persist(config)
       var key = getKey()
 
       provider.set(key, value, function (err, v) {
@@ -179,7 +180,7 @@ describe('Memory provider', () => {
 
   function testSetUndefined (config) {
     it('should not allow setting undefined', function (done) {
-      var provider = MemoryProvider(config)
+      var provider = Persist(config)
 
       provider.set(getKey(), undefined, function (err) {
         assert.isNotNull(err)
@@ -191,7 +192,7 @@ describe('Memory provider', () => {
 
   function testMiss (config) {
     it('should return undefined for misses', function (done) {
-      var provider = MemoryProvider()
+      var provider = Persist({ token: null })
 
       provider.get(getKey(), function (err, v) {
         assert.isNull(err)
@@ -204,7 +205,7 @@ describe('Memory provider', () => {
 
   function testMgetAllMisses (config) {
     it('should handle an mget w/ misses', function (done) {
-      var provider = MemoryProvider()
+      var provider = Persist({ token: null })
       var keys = [getKey(), getKey()]
 
       provider.mget(keys, function (err, values) {
@@ -218,7 +219,7 @@ describe('Memory provider', () => {
 
   function testMgetAllHits (config) {
     it('should handle an mget w/ all hits', function (done) {
-      var provider = MemoryProvider()
+      var provider = Persist({ token: null })
       var one = {
         key: getKey(),
         value: 1
@@ -247,7 +248,7 @@ describe('Memory provider', () => {
 
   function testMgetHitAndMiss (config) {
     it('should handle an mget w/ hit and miss', function (done) {
-      var provider = MemoryProvider()
+      var provider = Persist({ token: null })
       var one = {
         key: getKey(),
         value: 1

--- a/test/persist.test.js
+++ b/test/persist.test.js
@@ -8,6 +8,7 @@ describe('Beep Boop Persist', function () {
     })
 
     assert.equal(persist.type, 'memory')
+    assertInterface(persist)
   })
 
   it('should create a service provider when token is present', function () {
@@ -16,5 +17,14 @@ describe('Beep Boop Persist', function () {
     })
 
     assert.equal(persist.type, 'service')
+    assertInterface(persist)
   })
+
+  function assertInterface (persist) {
+    assert.isFunction(persist.get)
+    assert.isFunction(persist.mget)
+    assert.isFunction(persist.set)
+    assert.isFunction(persist.del)
+    assert.isFunction(persist.list)
+  }
 })

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -1,5 +1,6 @@
 var assert = require('chai').assert
 var nock = require('nock')
+var Persist = require('../index')
 var ServiceProvider = require('../lib/service-provider')
 
 describe('Service provider', () => {
@@ -13,7 +14,7 @@ describe('Service provider', () => {
     assert.doesNotThrow(function () {
       ServiceProvider({
         token: 'TOKEN',
-        url: 'https://persist'
+        url: 'http://persist'
       })
     })
   })
@@ -21,9 +22,10 @@ describe('Service provider', () => {
   it('should set without a callback', function (done) {
     var config = {
       token: 'TOKEN',
-      url: 'https://persist'
+      url: 'http://persist',
+      serialize: false
     }
-    var provider = ServiceProvider(config)
+    var provider = Persist(config)
     var value = 'value'
     var key = getKey()
 
@@ -45,11 +47,12 @@ describe('Service provider', () => {
   describe('list keys', function () {
     var config = {
       token: 'TOKEN',
-      url: 'https://persist'
+      url: 'http://persist',
+      serialize: false
     }
 
     it('should handle no keys', function (done) {
-      var provider = ServiceProvider(config)
+      var provider = Persist(config)
 
       var getKeys = nock(config.url)
         .get('/persist/kv')
@@ -66,7 +69,7 @@ describe('Service provider', () => {
     })
 
     it('should return keys after set', function (done) {
-      var provider = ServiceProvider(config)
+      var provider = Persist(config)
       var keys = [getKey(), getKey()]
       var values = ['beep', 'boop']
 
@@ -109,7 +112,7 @@ describe('Service provider', () => {
     })
 
     it("shouldn't return a key after del", function (done) {
-      var provider = ServiceProvider(config)
+      var provider = Persist(config)
       var key = getKey()
       var value = 'beep'
 
@@ -160,7 +163,7 @@ describe('Service provider', () => {
     })
 
     it('should filter keys', function (done) {
-      var provider = ServiceProvider(config)
+      var provider = Persist(config)
       var key1 = 'beep'
       var key2 = 'boop'
       var value = 'beepboop'
@@ -234,7 +237,7 @@ describe('Service provider', () => {
 
   describe('without serialize', function () {
     var config = {
-      url: 'https://persist',
+      url: 'http://persist',
       token: 'TOKEN',
       serialize: false
     }
@@ -253,7 +256,7 @@ describe('Service provider', () => {
 
   describe('with serialize', function () {
     var config = {
-      url: 'https://persist',
+      url: 'http://persist',
       token: 'TOKEN',
       serialize: true
     }
@@ -272,7 +275,7 @@ describe('Service provider', () => {
 
   function testSetGetDelGet (config, value) {
     it('should handle "' + value + '"', function (done) {
-      var service = ServiceProvider(config)
+      var service = Persist(config)
       var key = getKey()
       var preparedValue = config.serialize ? JSON.stringify(value) : value
 
@@ -327,7 +330,7 @@ describe('Service provider', () => {
 
   function testMiss (config) {
     it('should return undefined for misses', function (done) {
-      var provider = ServiceProvider(config)
+      var provider = Persist(config)
       var key = getKey()
 
       var get = nock(config.url)
@@ -346,7 +349,7 @@ describe('Service provider', () => {
 
   function testSetUndefined (config) {
     it('should not allow setting undefined', function (done) {
-      var service = ServiceProvider(config)
+      var service = Persist(config)
 
       service.set(getKey(), undefined, function (err) {
         assert.isNotNull(err)
@@ -358,7 +361,7 @@ describe('Service provider', () => {
 
   function testMgetAllMisses (config) {
     it('should handle an mget w/ misses', function (done) {
-      var provider = ServiceProvider(config)
+      var provider = Persist(config)
       var keys = [getKey(), getKey()]
 
       var mget = nock(config.url)
@@ -377,7 +380,7 @@ describe('Service provider', () => {
 
   function testMgetHitAndMiss (config) {
     it('should handle an mget w/ hit and miss', function (done) {
-      var provider = ServiceProvider(config)
+      var provider = Persist(config)
       var one = {
         key: getKey(),
         value: 1
@@ -420,7 +423,7 @@ describe('Service provider', () => {
 
   function testMgetAllHits (config) {
     it('should handle an mget w/ all hits', function (done) {
-      var provider = ServiceProvider(config)
+      var provider = Persist(config)
       var one = {
         key: getKey(),
         value: 1


### PR DESCRIPTION
- Adds the ability to get debug/error log messages via setting a `debug` option to `true`:

``` javascript
var persist = Persist({
  debug: true
})
```

When enabled, output looks as follows:

```
debug: set(testkey)
debug: list()
debug: del(testkey)
debug: get(testkey)
debug: mget([testkey,testkey2])
error: Error calling set(testkey): cannot set a value of undefined
```

I ended up having the top lvl function return an object wrapping the provider instead of provider directly - this provides a single place to normalize optional args (like the optional callback for set) and mix in logging.

I refactored the tests to not use the providers directly, but to go through the top lvl Persist fn to get an instance.  This is slightly awkward due to having to set the `token` to `null` in order to get a `Service` provider - but that'll be addressed in #4 

Fixes #3 
