### PR TITLE
updating options docs and allowing logger to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ kv.set('a key', 'the key, is water', function (err) {
 Returns a Beep Boop Perist api:
 
 + `options.serialize` - defaults to `true` - all values will be run through `JSON.stringify()` and `JSON.parse()`
-+ `options.token` - defaults to `process.env.BEEPBOOP_TOKEN` - if this isn't present, a memory provider will be used instead of the real service
-+ `options.url` - defaults to `https://persist` - which is the Beep Boop persist service
++ `options.token` - defaults to `process.env.BEEPBOOP_TOKEN` - auth token passed into environment by Beep Boop
++ `options.url` - defaults to `process.env.BEEPBOOP_PERSIST_URL` - service url passed into environment by Beep Boop
++ `options.debug` - defaults to `false` - if `true` then api calls and errors are logged.
++ `options.logger` - defaults to `null` - Should be an object w/ a `debug` and `error` function.
++ `options.provider` - defaults to `null`, acceptable values are `"memory"` or `"beepboop"` - this provides a way to override provider selection logic.  If this isn't explicitly set, then the `"beepboop"` provider is used when both `token` and `url` are present.  Otherwise the `"memory"` provider is used.
 
 ### .get(key, callback)
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var providers = {
 
 module.exports = function NewKV (options) {
   var config = deap.update({
+    logger: null, // override logger
     provider: null, // select provider strategy explicitly ('memory'||'beepboop')
     debug: false, // enables logging of calls/errors
     serialize: true, // JSON.stringify/parse on set/get


### PR DESCRIPTION
Missing a few things in the options docs.  Also wasn't allowing `logger` to be overridden.
