### PR TITLE
adds fallback and default for the service url

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Returns a Beep Boop Perist api:
 
 + `options.serialize` - defaults to `true` - all values will be run through `JSON.stringify()` and `JSON.parse()`
 + `options.token` - defaults to `process.env.BEEPBOOP_TOKEN` - auth token passed into environment by Beep Boop
-+ `options.url` - defaults to `process.env.BEEPBOOP_PERSIST_URL` - service url passed into environment by Beep Boop. If running outside of Beep Boop but still want to call the service, should be `https://beepboophq.com/api/v1/persist`.
++ `options.url` - defaults to `process.env.BEEPBOOP_PERSIST_URL || process.env.BEEPBOOP_API_URL || 'https://beepboophq.com/api/v1'` - service url passed into environment by Beep Boop
 + `options.debug` - defaults to `false` - if `true` then api calls and errors are logged.
 + `options.logger` - defaults to `null` - Should be an object w/ a `debug` and `error` function.
 + `options.provider` - defaults to `null`, acceptable values are `"memory"`, `"beepboop"`, or `"fs"` - this provides a way to override provider selection logic.  If this isn't explicitly set, then the `"beepboop"` provider is used when both `token` and `url` are present.  Otherwise the `"memory"` provider is used. `"fs"` can be used when running outside of Beep Boop to make data survive restarts. This provider shouldn't be used while running on Beep Boop though since the disks are ephemeral.

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function NewKV (options) {
     debug: false, // enables logging of calls/errors
     serialize: true, // JSON.stringify/parse on set/get
     token: process.env.BEEPBOOP_TOKEN, // auth token
-    url: process.env.BEEPBOOP_PERSIST_URL, // persist endpoint
+    url: process.env.BEEPBOOP_PERSIST_URL || process.env.BEEPBOOP_API_URL || 'https://beepboophq.com/api/v1', // persist endpoint
     directory: null // only for filesystem provider
   }, options || {})
 


### PR DESCRIPTION
Populates `url` via `BEEPBOOP_PERSIST_URL` if present, otherwise `BEEPBOOP_API_URL` or defaults to `https://beepboophq.com/api/v1`.

Motivation behind this is to make it a bit easier to get up and running locally with this module and provide some sensible defaults that play well with higher level beepboop modules, like `botkit-storage-beepboop` that uses this internally.